### PR TITLE
fixed error in kata/text canvas js

### DIFF
--- a/CodingDojo/games/kata/src/main/webapp/resources/js/kata.js
+++ b/CodingDojo/games/kata/src/main/webapp/resources/js/kata.js
@@ -85,7 +85,6 @@ game.onBoardAllPageLoad = function() {
 game.playerDrawer = function (canvas, playerName, gameName,
         data, heroesData, defaultPlayerDrawer)
 {
-    canvas.resizeHeight(data.history.length + 1);
     canvas.clear();
 
     description = unescapeUnicode(data.description);

--- a/CodingDojo/server/src/main/webapp/resources/js/board.js
+++ b/CodingDojo/server/src/main/webapp/resources/js/board.js
@@ -71,7 +71,7 @@ function initBoardComponents(game) {
         initCanvasesText(game.contextPath, game.players, game.allPlayersScreen,
                         game.singleBoardGame, game.boardSize,
                         game.gameName, game.enablePlayerInfo,
-                        game.enablePlayerInfoLevel, game.drawBoard);
+                        game.enablePlayerInfoLevel, game.playerDrawer);
     }
 
     if (game.enableDonate) {

--- a/CodingDojo/server/src/main/webapp/resources/js/canvases-text.js
+++ b/CodingDojo/server/src/main/webapp/resources/js/canvases-text.js
@@ -124,7 +124,7 @@ function initCanvasesText(contextPath, players, allPlayersScreen,
     }
 
     var getBoardDrawer = function(canvas, playerName, playerData) {
-        var board = playerData.board;
+        var data = playerData.board;
         var heroesData = playerData.heroesData[playerName];
 
         var clear = function() {
@@ -148,13 +148,14 @@ function initCanvasesText(contextPath, players, allPlayersScreen,
             clear : clear,
             drawLines : drawLines,
             canvas : canvas,
+            drawText: canvas.drawText,
             playerName : playerName,
             playerData : playerData
         };
     }
 
     function defaultDrawBoard(drawer) {
-        drawer.clean();
+        drawer.clear();
         drawer.drawLines();
     }
 
@@ -317,7 +318,7 @@ function initCanvasesText(contextPath, players, allPlayersScreen,
 
        var canvas = canvases[playerName];
        canvas.boardSize = boardSize;
-       drawBoard(getBoardDrawer(canvas, playerName, data));
+       drawBoard(getBoardDrawer(canvas, playerName, data), playerName, data.gameName, data.board, data.heroesData);
 
         $("#score_" + toId(playerName)).text(data.score);
 


### PR DESCRIPTION
Kata в 1.0.24 падает с ошибкой на фронте, вызывается несуществующая функция чистки canvas'а. В функцию отрисовки передаются не все необходимые параметры, не выводится задание при нажатии на лейбл.