### PR TITLE
Фикс: столкновения должны обрабатываться до съедания объектов.

### DIFF
--- a/CodingDojo/games/snake-battle/src/main/java/com/codenjoy/dojo/snakebattle/model/board/SnakeBoard.java
+++ b/CodingDojo/games/snake-battle/src/main/java/com/codenjoy/dojo/snakebattle/model/board/SnakeBoard.java
@@ -136,6 +136,10 @@ public class SnakeBoard implements Field {
 
         snakesMove();
         snakesFight();
+        snakesEat();
+        // после еды у змеек отрастают хвосты, поэтому столкновения нужно повторить
+        // чтобы обработать ситуацию "кусь за растущий хвост", иначе eatTailThatGrows тесты не пройдут
+        snakesFight();
         fireWinEvents();
         setNewObjects();
     }
@@ -200,29 +204,7 @@ public class SnakeBoard implements Field {
     private void snakesMove() {
         for (Player player : aliveActive()) {
             Hero hero = player.getHero();
-            Point head = hero.getNextPoint();
             hero.tick();
-
-            if (apples.contains(head)) {
-                apples.remove(head);
-                player.event(Events.APPLE);
-            }
-            if (stones.contains(head) && !hero.isFlying()) {
-                stones.remove(head);
-                if (player.isAlive()) {
-                    player.event(Events.STONE);
-                }
-            }
-            if (gold.contains(head)) {
-                gold.remove(head);
-                player.event(Events.GOLD);
-            }
-            if (flyingPills.contains(head)) {
-                flyingPills.remove(head);
-            }
-            if (furyPills.contains(head)) {
-                furyPills.remove(head);
-            }
         }
     }
 
@@ -292,6 +274,35 @@ public class SnakeBoard implements Field {
                     hero.clearReduced();
                     hero.event(Events.EAT.apply(i.reduce));
                 });
+    }
+
+    private void snakesEat() {
+        for (Player player : aliveActive()) {
+            Hero hero = player.getHero();
+            Point head = hero.head();
+            hero.eat();
+
+            if (apples.contains(head)) {
+                apples.remove(head);
+                player.event(Events.APPLE);
+            }
+            if (stones.contains(head) && !hero.isFlying()) {
+                stones.remove(head);
+                if (player.isAlive()) {
+                    player.event(Events.STONE);
+                }
+            }
+            if (gold.contains(head)) {
+                gold.remove(head);
+                player.event(Events.GOLD);
+            }
+            if (flyingPills.contains(head)) {
+                flyingPills.remove(head);
+            }
+            if (furyPills.contains(head)) {
+                furyPills.remove(head);
+            }
+        }
     }
 
     private Stream<Hero> notFlyingHeroes() {

--- a/CodingDojo/games/snake-battle/src/main/java/com/codenjoy/dojo/snakebattle/model/hero/Hero.java
+++ b/CodingDojo/games/snake-battle/src/main/java/com/codenjoy/dojo/snakebattle/model/hero/Hero.java
@@ -214,7 +214,8 @@ public class Hero extends PlayerHero<Field> implements State<LinkedList<Tail>, P
         Point head = head();
         if (field.isApple(head)) {
             growBy(1);
-            // it should be done here
+            // если не сделать этого здесь, при съедании яблока и одновременной потере части корпуса
+            // яблоко будет зачтено лишь на следующий тик, что неправильно
             grow();
         }
         if (field.isStone(head) && !isFlying()) {

--- a/CodingDojo/games/snake-battle/src/main/java/com/codenjoy/dojo/snakebattle/model/hero/Hero.java
+++ b/CodingDojo/games/snake-battle/src/main/java/com/codenjoy/dojo/snakebattle/model/hero/Hero.java
@@ -53,6 +53,7 @@ public class Hero extends PlayerHero<Field> implements State<LinkedList<Tail>, P
     private Player player;
     private boolean leaveApples;
     private boolean reduced;
+    private Point lastTailPosition;
 
     public Hero(Point xy) {
         this(RIGHT);
@@ -197,29 +198,38 @@ public class Hero extends PlayerHero<Field> implements State<LinkedList<Tail>, P
         count();
 
         Point next = getNextPoint();
+        if (isMe(next) && !isFlying())
+            selfReduce(next);
 
-        if (field.isApple(next))
+        go(next);
+    }
+
+    // Этот метод должен вызываться отдельно от tick,
+    // уже после обработки столкновений с другими змейками
+    public void eat() {
+        if (!isActiveAndAlive()) {
+            return;
+        }
+
+        Point head = head();
+        if (field.isApple(head)) {
             growBy(1);
-        if (field.isStone(next) && !isFlying()) {
+            // it should be done here
+            grow();
+        }
+        if (field.isStone(head) && !isFlying()) {
             stonesCount++;
             if (!isFury()) {
                 reduce(field.stoneReduced().getValue(), NOW);
                 clearReduced();
             }
         }
-        if (field.isFlyingPill(next))
+        if (field.isFlyingPill(head))
             flyingCount += field.flyingCount().getValue();
-        if (field.isFuryPill(next))
+        if (field.isFuryPill(head))
             furyCount += field.furyCount().getValue();
-        if (field.isBarrier(next))
+        if (field.isBarrier(head))
             die();
-        if (isMe(next) && !isFlying())
-            selfReduce(next);
-
-        if (growBy > 0)
-            grow(next);
-        else
-            go(next);
     }
 
     private void count() {
@@ -277,12 +287,13 @@ public class Hero extends PlayerHero<Field> implements State<LinkedList<Tail>, P
         return getPointAt(head(), direction);
     }
 
-    private void grow(Point newLocation) {
+    private void grow() {
         growBy--;
-        elements.add(new Tail(newLocation, this));
+        elements.addFirst(new Tail(lastTailPosition, this));
     }
 
     private void go(Point newLocation) {
+        lastTailPosition = getTailPoint();
         elements.add(new Tail(newLocation, this));
         elements.removeFirst();
     }

--- a/CodingDojo/games/snake-battle/src/test/java/com/codenjoy/dojo/snakebattle/model/SnakeHeroTest.java
+++ b/CodingDojo/games/snake-battle/src/test/java/com/codenjoy/dojo/snakebattle/model/SnakeHeroTest.java
@@ -80,6 +80,7 @@ public class SnakeHeroTest {
         int before = hero.size();
         applesAtAllPoints(true);// впереди яблоко -> увеличиваем змейку
         hero.tick();
+        hero.eat();
         applesAtAllPoints(false);
         assertEquals("Змейка не увеличилась!", before + 1, hero.size());
     }
@@ -91,23 +92,27 @@ public class SnakeHeroTest {
         LinkedList<Tail> startBody = new LinkedList<>(hero.getBody());
         // просто тик
         hero.tick();
+        hero.eat();
         assertEquals("Неактивная змейка изменилась!", startBody, hero.getBody());
         assertTrue("Змейка мертва!", hero.isAlive());
         // если яблоко
         applesAtAllPoints(true);
         hero.tick();
+        hero.eat();
         applesAtAllPoints(false);
         assertEquals("Неактивная змейка изменилась!", startBody, hero.getBody());
         assertTrue("Змейка мертва!", hero.isAlive());
         // если камень
         stonesAtAllPoints(true);
         hero.tick();
+        hero.eat();
         stonesAtAllPoints(false);
         assertEquals("Неактивная змейка изменилась!", startBody, hero.getBody());
         assertTrue("Змейка мертва!", hero.isAlive());
         // если стена
         wallsAtAllPoints(true);
         hero.tick();
+        hero.eat();
         wallsAtAllPoints(false);
         assertEquals("Неактивная змейка изменилась!", startBody, hero.getBody());
         assertTrue("Змейка мертва!", hero.isAlive());
@@ -119,6 +124,7 @@ public class SnakeHeroTest {
         int before = hero.size();
         wallsAtAllPoints(true);// впереди яблоко -> увеличиваем змейку
         hero.tick();
+        hero.eat();
         wallsAtAllPoints(false);
         assertTrue("Змейка не погибла от препятствия!", !hero.isAlive());
     }
@@ -129,6 +135,7 @@ public class SnakeHeroTest {
         snakeIncreasing(stoneReduced.getValue() - 1);
         stonesAtAllPoints(true);// впереди камень
         hero.tick();
+        hero.eat();
         stonesAtAllPoints(false);
         assertTrue("Маленькая змейка не погибла от камня!", !hero.isAlive());
     }
@@ -140,10 +147,12 @@ public class SnakeHeroTest {
         int before = hero.size();
         stonesAtAllPoints(true);// впереди камень
         hero.tick();
+        hero.eat();
         stonesAtAllPoints(false);
         assertTrue("Большая змейка погибла от камня!", hero.isAlive());
         assertEquals("Змейка не укоротилась на предполагаемую длину!", before - stoneReduced.getValue(), hero.size());
         hero.tick();
+        hero.eat();
     }
 
     // змейка может откусить себе хвост
@@ -154,10 +163,13 @@ public class SnakeHeroTest {
         assertEquals("Змейка не удлиннилась!", additionLength + 2, hero.size());
         hero.down();
         hero.tick();
+        hero.eat();
         hero.left();
         hero.tick();
+        hero.eat();
         hero.up();
         hero.tick();
+        hero.eat();
         assertTrue("Змейка погибла укусив свой хвост!", hero.isAlive());
         assertEquals("Укусив свой хвост, змейка не укоротилась!", 4, hero.size());
     }
@@ -172,8 +184,10 @@ public class SnakeHeroTest {
             snakeIncreasing(additionLength);
             stonesAtAllPoints(true);
             hero.tick();
+            hero.eat();
             stonesAtAllPoints(false);
             hero.tick();
+            hero.eat();
             assertTrue("Змейка погибла!", hero.isAlive());
             assertEquals("Съев камень, он не появился внутри змейки!", ++stonesCount, hero.getStonesCount());
         }
@@ -199,9 +213,11 @@ public class SnakeHeroTest {
     public void eatFlyingPill() {
         flyingPillsAtAllPoints(true);
         hero.tick();
+        hero.eat();
         flyingPillsAtAllPoints(false);
         for (int i = 1; i <= 10; i++) {
             hero.tick();
+            hero.eat();
             assertEquals("Оставшееся количество ходов полёта не соответствует ожидаемому.",
                     10 - i, hero.getFlyingCount());
         }
@@ -213,11 +229,13 @@ public class SnakeHeroTest {
     public void eatFuryPill() {
         furyPillsAtAllPoints(true);
         hero.tick();
+        hero.eat();
         furyPillsAtAllPoints(false);
         for (int i = 0; i <= 10; i++) {
             assertEquals("Оставшееся количество ходов ярости не соответствует ожидаемому.",
                     10 - i, hero.getFuryCount());
             hero.tick();
+            hero.eat();
         }
         assertEquals("Количество ходов ярости не может быть меньше 0.", 0, hero.getFuryCount());
     }


### PR DESCRIPTION
Фикс бага: результат столкновения двух змеек над каким-либо объектом (таблетка злости, яблоко, камень) не должен зависеть от порядка игроков на сервере.

Для этого нужно поменять порядок обработки ходов змеек. Сначала просто двигаем змейки, потом обрабатываем столкновения, потом едим объекты под головами выживших змеек, потом еще раз обрабатываем столкновения чтобы покрыть кейс укуса за хвост змейки которая съедает яблоко. 

Метод hero.tick() пришлось разбить на два, логика по съеданию объектов вынесена в hero.eat().