### PR TITLE
Feature/chat service java docs and vulnerabilities

### DIFF
--- a/CodingDojo/server/src/main/java/com/codenjoy/dojo/services/ChatService.java
+++ b/CodingDojo/server/src/main/java/com/codenjoy/dojo/services/ChatService.java
@@ -91,11 +91,10 @@ public class ChatService {
         return playerNames.get(playerId);
     }
 
-    // TODO я могу получить сообщение из другой комнаты, главное задать
-    //      room плеера делающего запрос, а вот id можно указать любое
     public List<PMessage> getTopicMessages(int topicMessageId, String room, String playerId) {
         // TODO по сути будет по 2 запроса, что не ок по производительности
         //      можно было бы валидацию зашить во второй запрос?
+        // room validation only
         PMessage message = getMessage(topicMessageId, room, playerId);
 
         return wrap(chat.getTopicMessages(message.getId()));
@@ -118,7 +117,7 @@ public class ChatService {
 
         if (topicMessageId != null) {
             // TODO по сути на каждый риплай, будет по 2 запроса, что не ок по производительности
-            // only validation
+            // room validation only
             getMessage(topicMessageId, room, playerId);
         }
 

--- a/CodingDojo/server/src/main/java/com/codenjoy/dojo/services/ChatService.java
+++ b/CodingDojo/server/src/main/java/com/codenjoy/dojo/services/ChatService.java
@@ -94,6 +94,8 @@ public class ChatService {
     // TODO я могу получить сообщение из другой комнаты, главное задать
     //      room плеера делающего запрос, а вот id можно указать любое
     public List<PMessage> getTopicMessages(int topicMessageId, String room, String playerId) {
+        // TODO по сути будет по 2 запроса, что не ок по производительности
+        //      можно было бы валидацию зашить во второй запрос?
         PMessage message = getMessage(topicMessageId, room, playerId);
 
         return wrap(chat.getTopicMessages(message.getId()));
@@ -111,11 +113,14 @@ public class ChatService {
         return wrap(message);
     }
 
-    // TODO так же и тут, я могу запостить сообщение для topic-чата который находится
-    //      в другой комнате, для этого мне достаточно выбрать id сообщения из другого чата,
-    //      а так же указать комнату в которой я сейчас нахожусь.
     public PMessage postMessage(Integer topicMessageId, String text, String room, String playerId) {
         validateIsChatAvailable(playerId, room);
+
+        if (topicMessageId != null) {
+            // TODO по сути на каждый риплай, будет по 2 запроса, что не ок по производительности
+            // only validation
+            getMessage(topicMessageId, room, playerId);
+        }
 
         Chat.Message message = Chat.Message.builder()
                 .room(room)
@@ -125,7 +130,7 @@ public class ChatService {
                 .text(text)
                 .build();
 
-        chat.saveMessage(message);
+        message = chat.saveMessage(message);
 
         return wrap(message);
     }

--- a/CodingDojo/server/src/main/java/com/codenjoy/dojo/services/ChatService.java
+++ b/CodingDojo/server/src/main/java/com/codenjoy/dojo/services/ChatService.java
@@ -130,12 +130,10 @@ public class ChatService {
         return wrap(message);
     }
 
-    // TODO я могу удалять сообщения из другой комнаты, для этого мне достаточно выбрать id сообщения из другого чата,
-    //      а так же указать комнату в которой я сейчас нахожусь.
     public boolean deleteMessage(int messageId, String room, String playerId) {
         validateIsChatAvailable(playerId, room);
 
-        boolean deleted = chat.deleteMessage(messageId, playerId);
+        boolean deleted = chat.deleteMessage(room, messageId, playerId);
 
         if (!deleted) {
             throw exception("Player '%s' cant delete message with id '%s' in room '%s'",

--- a/CodingDojo/server/src/main/java/com/codenjoy/dojo/services/ChatService.java
+++ b/CodingDojo/server/src/main/java/com/codenjoy/dojo/services/ChatService.java
@@ -91,6 +91,8 @@ public class ChatService {
         return playerNames.get(playerId);
     }
 
+    // TODO я могу получить сообщение из другой комнаты, главное задать
+    //      room плеера делающего запрос, а вот id можно указать любое
     public List<PMessage> getTopicMessages(int topicMessageId, String room, String playerId) {
         PMessage message = getMessage(topicMessageId, room, playerId);
 
@@ -109,6 +111,9 @@ public class ChatService {
         return wrap(message);
     }
 
+    // TODO так же и тут, я могу запостить сообщение для topic-чата который находится
+    //      в другой комнате, для этого мне достаточно выбрать id сообщения из другого чата,
+    //      а так же указать комнату в которой я сейчас нахожусь.
     public PMessage postMessage(Integer topicMessageId, String text, String room, String playerId) {
         validateIsChatAvailable(playerId, room);
 
@@ -125,6 +130,8 @@ public class ChatService {
         return wrap(message);
     }
 
+    // TODO я могу удалять сообщения из другой комнаты, для этого мне достаточно выбрать id сообщения из другого чата,
+    //      а так же указать комнату в которой я сейчас нахожусь.
     public boolean deleteMessage(int messageId, String room, String playerId) {
         validateIsChatAvailable(playerId, room);
 

--- a/CodingDojo/server/src/main/java/com/codenjoy/dojo/services/dao/Chat.java
+++ b/CodingDojo/server/src/main/java/com/codenjoy/dojo/services/dao/Chat.java
@@ -216,11 +216,12 @@ public class Chat {
         return message;
     }
 
-    public boolean deleteMessage(int id, String playerId) {
+    public boolean deleteMessage(String room, int id, String playerId) {
         return 1 == pool.update("DELETE FROM messages " +
                 "WHERE id = ? " +
+                "AND room = ? " +
                 "AND player_id = ?",
-                new Object[]{id, playerId});
+                new Object[]{id, room, playerId});
     }
 
     private static List<Message> parseMessages(ResultSet rs) throws SQLException {

--- a/CodingDojo/server/src/main/java/com/codenjoy/dojo/web/rest/RestChatController.java
+++ b/CodingDojo/server/src/main/java/com/codenjoy/dojo/web/rest/RestChatController.java
@@ -35,6 +35,15 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.constraints.NotNull;
 
+/**
+ * Rest сервис для работы с чатом.
+ *
+ * Все запросы отсуществляются от лица пользователя
+ * с проверкой находится ли пользователь в заявленной комнате чатом которой интересуется,
+ * и может ли пользователь осуществлять эти действия.
+ *
+ * Если пользователь - админ системы, то он может осуществлять все действия с чатом.
+ */
 @RestController
 @Secured(GameAuthoritiesConstants.ROLE_USER)
 @RequestMapping(RestChatController.URI)

--- a/CodingDojo/server/src/main/java/com/codenjoy/dojo/web/rest/RestChatController.java
+++ b/CodingDojo/server/src/main/java/com/codenjoy/dojo/web/rest/RestChatController.java
@@ -47,6 +47,23 @@ public class RestChatController {
     private Validator validator;
     private ChatService chat;
 
+    /**
+     * Возвращает сообщения для room-чата с проверкой пользователя.
+     * Если пользователь не содержится в этом чате, сообщений он не получит.
+     * Возвращается заданное в фильтре (count, afterId, beforeId, inclusive)
+     * количество сообщений. Все параметры опциональны - в зависимости от
+     * их комбинации будет возвращено то или иное количество.
+     *
+     * @param room Имя комнаты, сообщения чата которой интересуют.
+     * @param count Количество сообщений, если указазаны afterId | beforeId
+     *              но не оба одновременно.
+     * @param afterId Получать сообщения после сообщения с этой id.
+     * @param beforeId Получать сообщения до сообщения с этой id.
+     * @param inclusive Включать ли в запрос сообщения с id afterId |& beforeId.
+     * @param user Пользователь осуществляющий запрос.
+     *             Если пользователя нет в комнате - сообщения получить неудастся.
+     * @return Заданное количество сообщений из room-чата.
+     */
     @GetMapping("/{room}/messages")
     public ResponseEntity<?> getMessages(
             @PathVariable(name = "room") String room,
@@ -62,6 +79,16 @@ public class RestChatController {
                 afterId, beforeId, inclusive, user.getId()));
     }
 
+    /**
+     * Метод для отправки сообщений в room-чат от имени конкретного пользователя.
+     *
+     * @param room Имя комнаты в чат которой отправится сообщение.
+     * @param message POJO с сообщением.
+     * @param user Пользователь осуществляющтий запрос.
+     *              Если пользователя нет в комнате - сообщение в чат не доставится.
+     * @return В случае успеха вернется опубликованное сообщение с новой id и
+ *              другими полями PMessage.
+     */
     @PostMapping("/{room}/messages")
     public ResponseEntity<?> postMessage(
             @PathVariable(name = "room") String room,
@@ -74,6 +101,19 @@ public class RestChatController {
                 room, user.getId()));
     }
 
+    /**
+     * Метод для отправки сообщений в thread-чат от имени конкретного пользователя.
+     * Thread-чат - это все reply сообщения на любое конкретное сообщение в любом чате.
+     *
+     * @param room Имя комнаты в чат которой отправится сообщение.
+     * @param id Указывает на родительское сообщение, reply к которому являются все
+     *           сообщения этого thread-чата.
+     * @param message POJO с сообщением.
+     * @param user Пользователь осуществляющтий запрос.
+     *              Если пользователя нет в комнате - сообщение в чат не доставится.
+     * @return В случае успеха вернется опубликованное сообщение с новой id,
+     *              ссылкой на topicId и другими полями PMessage.
+     */
     @PostMapping("/{room}/messages/{id}/replies")
     public ResponseEntity<?> postMessageForTopic(
             @PathVariable(name = "room") String room,
@@ -87,6 +127,15 @@ public class RestChatController {
                 room, user.getId()));
     }
 
+    /**
+     * Получение конкретного сообщения room-chat по его id.
+     *
+     * @param room Имя комнаты, сообщения чата которой интересуют
+     * @param id Идентификатор сообщения, которым интересуются.
+     * @param user Пользователь осуществляющтий запрос.
+     *            Если пользователя нет в комнате - сообщение получить неудастся.
+     * @return Найденное сообщение со своими полями размещенными в PMessage.
+     */
     @GetMapping("/{room}/messages/{id}")
     public ResponseEntity<?> getMessage(
             @PathVariable(name = "room") String room,
@@ -98,6 +147,17 @@ public class RestChatController {
         return ResponseEntity.ok(chat.getMessage(id, room, user.getId()));
     }
 
+    /**
+     * Получение всех thread-chat сообщений, привязанных к конкретному сообщению
+     * room-chat. Thread-чат - это все reply сообщения на любое конкретное
+     * сообщение в любом чате.
+     *
+     * @param room Имя комнаты, сообщения чата которой интересуют.
+     * @param id Идентификатор сообщения, reply-сообщениями которого интересуются.
+     * @param user Пользователь осуществляющтий запрос.
+     *            Если пользователя нет в комнате - сообщение получить неудастся.
+     * @return Список всех найденных сообщений со своими полями размещенными в PMessage.
+     */
     @GetMapping("/{room}/messages/{id}/replies")
     public ResponseEntity<?> getMessagesForTopic(
             @PathVariable(name = "room") String room,
@@ -109,6 +169,17 @@ public class RestChatController {
         return ResponseEntity.ok(chat.getTopicMessages(id, room, user.getId()));
     }
 
+    /**
+     * Удаление сообщения в room-chat или thread-chat от имени автора
+     * этого сообщения.
+     *
+     * @param room Имя комнаты, в чате которой удаляют сообщение.
+     * @param id Указывает на удаляемое сообщение.
+     * @param user Пользователь осуществляющтий запрос.
+     *           Если пользователя нет в комнате - сообщение удалить неудастся,
+     *             ровно как если пользователь не является автором этого сообщения.
+     * @return true - если сообщение успешно удалено.
+     */
     @DeleteMapping("/{room}/messages/{id}")
     public ResponseEntity<?> deleteMessage(
             @PathVariable(name = "room") String room,

--- a/CodingDojo/server/src/test/java/com/codenjoy/dojo/services/dao/ChatTest.java
+++ b/CodingDojo/server/src/test/java/com/codenjoy/dojo/services/dao/ChatTest.java
@@ -129,7 +129,7 @@ public class ChatTest {
                 chat.getLastMessageIds().toString());
 
         // when then
-        chat.deleteMessage(6, "player1");
+        chat.deleteMessage("room3", 6, "player1");
         assertEquals(Integer.valueOf(5), chat.getLastMessageId("room1"));
         assertEquals(Integer.valueOf(4), chat.getLastMessageId("room2"));
         assertEquals(null, chat.getLastMessageId("room3"));
@@ -137,7 +137,7 @@ public class ChatTest {
                 chat.getLastMessageIds().toString());
 
         // when then
-        chat.deleteMessage(5, "player2");
+        chat.deleteMessage("room1", 5, "player2");
         assertEquals(Integer.valueOf(3), chat.getLastMessageId("room1"));
         assertEquals(Integer.valueOf(4), chat.getLastMessageId("room2"));
         assertEquals(null, chat.getLastMessageId("room3"));
@@ -145,7 +145,7 @@ public class ChatTest {
                 chat.getLastMessageIds().toString());
 
         // when then
-        chat.deleteMessage(4, "player2");
+        chat.deleteMessage("room2", 4, "player2");
         assertEquals(Integer.valueOf(3), chat.getLastMessageId("room1"));
         assertEquals(null, chat.getLastMessageId("room2"));
         assertEquals(null, chat.getLastMessageId("room3"));
@@ -153,7 +153,7 @@ public class ChatTest {
                 chat.getLastMessageIds().toString());
 
         // when then
-        chat.deleteMessage(3, "player2");
+        chat.deleteMessage("room1", 3, "player2");
         assertEquals(Integer.valueOf(2), chat.getLastMessageId("room1"));
         assertEquals(null, chat.getLastMessageId("room2"));
         assertEquals(null, chat.getLastMessageId("room3"));
@@ -161,7 +161,7 @@ public class ChatTest {
                 chat.getLastMessageIds().toString());
 
         // when then
-        chat.deleteMessage(2, "player1");
+        chat.deleteMessage("room1", 2, "player1");
         assertEquals(Integer.valueOf(1), chat.getLastMessageId("room1"));
         assertEquals(null, chat.getLastMessageId("room2"));
         assertEquals(null, chat.getLastMessageId("room3"));
@@ -169,7 +169,7 @@ public class ChatTest {
                 chat.getLastMessageIds().toString());
 
         // when then
-        chat.deleteMessage(1, "player1");
+        chat.deleteMessage("room1", 1, "player1");
         assertEquals(null, chat.getLastMessageId("room1"));
         assertEquals(null, chat.getLastMessageId("room2"));
         assertEquals(null, chat.getLastMessageId("room3"));
@@ -308,21 +308,21 @@ public class ChatTest {
                 .in(chat.getMessages("room", 10));
 
         // when
-        assertEquals(true, chat.deleteMessage(1, "player1"));
+        assertEquals(true, chat.deleteMessage("room", 1, "player1"));
 
         // then
         assertThat(2, 3, 4)
                 .in(chat.getMessages("room", 10));
 
         // when
-        assertEquals(true, chat.deleteMessage(3, "player2"));
+        assertEquals(true, chat.deleteMessage("room", 3, "player2"));
 
         // then
         assertThat(2, 4)
                 .in(chat.getMessages("room", 10));
 
         // when
-        assertEquals(true, chat.deleteMessage(4, "player3"));
+        assertEquals(true, chat.deleteMessage("room", 4, "player3"));
 
         // then
         assertThat(2)
@@ -330,9 +330,21 @@ public class ChatTest {
     }
 
     @Test
-    public void shouldDeleteMessageById_whenNotExists() {
+    public void shouldDeleteMessageById_whenRoomNotExists() {
+        // given
+        addMessage("room", "player"); // id = 1
+
         // when then
-        assertEquals(false, chat.deleteMessage(100500, "player"));
+        assertEquals(false, chat.deleteMessage("otherRoom", 1, "player"));
+    }
+
+    @Test
+    public void shouldDeleteMessageById_whenInvalidRoom() {
+        // given
+        addMessage("room", "player"); // id = 1
+
+        // when then
+        assertEquals(false, chat.deleteMessage("room", 100500, "player"));
     }
 
     @Test
@@ -345,7 +357,7 @@ public class ChatTest {
                 .in(chat.getMessages("room", 10));
 
         // when then
-        assertEquals(false, chat.deleteMessage(1, "otherPlayer"));
+        assertEquals(false, chat.deleteMessage("room", 1, "otherPlayer"));
     }
 
     @Test

--- a/CodingDojo/server/src/test/java/com/codenjoy/dojo/web/rest/AbstractRestControllerTest.java
+++ b/CodingDojo/server/src/test/java/com/codenjoy/dojo/web/rest/AbstractRestControllerTest.java
@@ -224,6 +224,10 @@ public abstract class AbstractRestControllerTest {
         return deal;
     }
 
+    protected void assertPlayerInRoom(String id, String room) {
+        Player player = players.get(id);
+        assertEquals(room, player.getRoom());
+    }
 
     protected void join(String id, String room) {
         Player player = players.get(id);

--- a/CodingDojo/server/src/test/java/com/codenjoy/dojo/web/rest/AbstractRestControllerTest.java
+++ b/CodingDojo/server/src/test/java/com/codenjoy/dojo/web/rest/AbstractRestControllerTest.java
@@ -303,6 +303,11 @@ public abstract class AbstractRestControllerTest {
         }
     }
 
+    protected void assertGetError(String message, String uri) {
+        String source = get(500, uri);
+        JSONObject error = tryParseAsJson(source);
+        assertEquals(message, error.getString("message"));
+    }
     protected void assertPostError(String message, String uri, String data) {
         String source = post(500, uri, data);
         JSONObject error = tryParseAsJson(source);

--- a/CodingDojo/server/src/test/java/com/codenjoy/dojo/web/rest/AbstractRestControllerTest.java
+++ b/CodingDojo/server/src/test/java/com/codenjoy/dojo/web/rest/AbstractRestControllerTest.java
@@ -224,6 +224,13 @@ public abstract class AbstractRestControllerTest {
         return deal;
     }
 
+
+    protected void join(String id, String room) {
+        Player player = players.get(id);
+        player.setRoom(room);
+        players.update(player);
+    }
+
     private void resetMocks(Deal deal) {
         reset(deal.getField());
         reset(deal.getGame().getPlayer());

--- a/CodingDojo/server/src/test/java/com/codenjoy/dojo/web/rest/RestBoardControllerTest.java
+++ b/CodingDojo/server/src/test/java/com/codenjoy/dojo/web/rest/RestBoardControllerTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 
-import static org.junit.Assert.assertEquals;
+import static com.codenjoy.dojo.stuff.SmartAssert.assertEquals;
 
 @Import(RestBoardControllerTest.ContextConfiguration.class)
 public class RestBoardControllerTest extends AbstractRestControllerTest {

--- a/CodingDojo/server/src/test/java/com/codenjoy/dojo/web/rest/RestChatControllerTest.java
+++ b/CodingDojo/server/src/test/java/com/codenjoy/dojo/web/rest/RestChatControllerTest.java
@@ -126,7 +126,7 @@ public class RestChatControllerTest extends AbstractRestControllerTest {
     }
 
     @Test
-    public void shouldDeleteMessages_cantDeleteWhenNotMyMessage() {
+    public void shouldDeleteMessages_cantDelete_whenNotMyMessage() {
         // given
         // id = 1
         nowIs(12345L);
@@ -146,7 +146,40 @@ public class RestChatControllerTest extends AbstractRestControllerTest {
     }
 
     @Test
-    public void shouldDeleteMessages_cantDeleteWhenNotExistsMessage() {
+    public void shouldDeleteMessages_cantDelete_whenNotMyRoom() {
+        // given
+        // id = 1
+        // create message in validRoom
+        nowIs(12345L);
+        post(200, "/rest/chat/validRoom/messages",
+                unquote("{text:'message1'}"));
+
+        assertEquals("[{'id':1,'playerId':'player','playerName':'player-name','room':'validRoom','text':'message1','time':12345,'topicId':null}]",
+                fix(get("/rest/chat/validRoom/messages")));
+
+        // when
+        // rejoin in new room
+        join("player", "otherRoom");
+
+        // then
+        // cant delete message from old room
+        // (only by id = 1, room = player.room != message.room)
+        assertDeleteError("java.lang.IllegalArgumentException: " +
+                        "Player 'player' cant delete message with id " +
+                        "'1' in room 'otherRoom'",
+                "/rest/chat/otherRoom/messages/1");
+
+        // when
+        // come back in old room again
+        join("player", "validRoom");
+
+        // message in still there
+        assertEquals("[{'id':1,'playerId':'player','playerName':'player-name','room':'validRoom','text':'message1','time':12345,'topicId':null}]",
+                fix(get("/rest/chat/validRoom/messages")));
+    }
+
+    @Test
+    public void shouldDeleteMessages_cantDelete_whenNotExistsMessage() {
         // when then
         assertDeleteError("java.lang.IllegalArgumentException: " +
                         "Player 'player' cant delete message with id " +

--- a/CodingDojo/server/src/test/java/com/codenjoy/dojo/web/rest/RestChatControllerTest.java
+++ b/CodingDojo/server/src/test/java/com/codenjoy/dojo/web/rest/RestChatControllerTest.java
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.Import;
 
 import java.util.stream.IntStream;
 
-import static org.junit.Assert.assertEquals;
+import static com.codenjoy.dojo.stuff.SmartAssert.assertEquals;
 import static org.mockito.Mockito.when;
 
 @Import(RestChatControllerTest.ContextConfiguration.class)


### PR DESCRIPTION
Added javadocs for rest service.

Fixed bug: I can delete messages from another room-chat, for this I just need to select the message id from another room-chat, as well as indicate the room in which I am now.

Fixed bug: I can post a message for a topic-chat which is in another room, for this I just need to select the id of the message from another chat, as well as indicate the room in which I am now.

Checked case: I can get topic messages from another room, the main thing is to set the room of the player making the request.